### PR TITLE
Use extra_applications instead of applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule Numerix.Mixfile do
   end
 
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger]]
   end
 
   defp deps do


### PR DESCRIPTION
related articles:
- https://www.amberbit.com/blog/2019/8/23/mix-release-and-missing-dependencies/
- https://www.amberbit.com/blog/2017/9/22/elixir-applications-vs-extra_applications-guide/